### PR TITLE
Introduce --stdin / - option

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -81,7 +81,7 @@ def main(
         return
 
     if not prompt and not editor:
-        if stdin or not sys.stdin.isatty():
+        if stdin:
             prompt = sys.stdin.read()
         else:
             raise MissingParameter(param_hint="PROMPT", param_type="string")

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -87,7 +87,7 @@ def main(
             raise MissingParameter(param_hint="PROMPT", param_type="string")
     elif prompt and stdin:
         stdin_data = sys.stdin.read()
-        prompt = f"{stdin_data.strip()}\n{prompt}"
+        prompt = f"{prompt}\n{stdin_data.strip()}"
 
     if editor:
         prompt = get_edited_prompt()

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -48,6 +48,16 @@ def get_completion(
     )
 
 
+# typer does not parse '-' like it does with other options
+# So we instead parse '-' and '--stdin' options here, before invoking typer
+stdin = False
+if "-" in sys.argv:
+    stdin = True
+    sys.argv.remove("-")
+if "--stdin" in sys.argv:
+    stdin = True
+    sys.argv.remove("--stdin")
+
 def main(
     prompt: str = typer.Argument(None, show_default=False, help="The prompt to generate completions for."),
     temperature: float = typer.Option(1.0, min=0.0, max=1.0, help="Randomness of generated output."),
@@ -62,7 +72,6 @@ def main(
     cache: bool = typer.Option(True, help="Cache completion results."),
     animation: bool = typer.Option(True, help="Typewriter animation."),
     spinner: bool = typer.Option(True, help="Show loading spinner during API request."),
-    stdin: bool = typer.Option(False, "--stdin", "-", help="Read prompt from standard input.", allow_dash=True),
 ) -> None:
     if list_chat:
         echo_chat_ids()
@@ -70,12 +79,6 @@ def main(
     if show_chat:
         echo_chat_messages(show_chat)
         return
-
-    # Typer does not actually parse the "-", so it ends up in the prompt. We can extract it from there:
-    # BUG: But this means that we cannot have a prompt when passing -
-    if prompt == "-":
-        stdin = True
-        prompt = None
 
     if not prompt and not editor:
         if stdin or not sys.stdin.isatty():


### PR DESCRIPTION
I think my comments on [your PR](https://github.com/TheR1D/shell_gpt/pull/86) got a bit crazy long. So I thought I'd summarise here.

This tweak to your PR makes `sgpt` more Unix-like.

It has the following features:

- It will only read from stdin if `--stdin` or `-` are passed.
- It doesn't check what type stdin is. This makes it predictable.
- The bug I had where typer would not parse the `-` is now fixed by manipulating `argv` directly.

In other words:

```
# Valid
sgpt [prompt]
... | sgpt -
... | sgpt - [prompt]
... | sgpt [prompt] -

# Invalid
sgpt
... | sgpt
```

It might be reasonable for `sgpt` to always read from stdin if no prompt is provided. `cat` `grep` and `gzip` work like that. But it might be confusing for new users.

(Actually plain `sgpt` might be a good way to enter interactive REPL with ChatGPT in the future.)

---

Previously, the first rule was:

- It will read from stdin if `--stdin` is passed, or if no prompt is given and the input is a non-terminal

But I changed that because I had a concern about it.

It means `sgpt` will act differently depending on what type of stdin is offered, which seems like unpredictable behaviour.

For example, a user might create an sgpt command which works when they run it on their terminal, but acts differently when they put it in a script (when stdin is not a TTY).

My preference would be for sgpt to only read from stdin if `--stdin` or `-` are explicitly passed. This would make the behaviour very predictable, albeit less convenient.

Alternatively, `sgpt` with no prompt and no opt-in could always read from stdin, regardless of the type of stdin.

To address that concern, I have made reading from stdin opt-in only.